### PR TITLE
Update version, add new method to return meta string

### DIFF
--- a/disable-user-login.php
+++ b/disable-user-login.php
@@ -3,7 +3,7 @@
  * Plugin Name: Disable User Login
  * Plugin URI:  http://wordpress.org/plugins/disable-user-login
  * Description: Provides the ability to disable user accounts and prevent them from logging in.
- * Version:     1.3.1
+ * Version:     1.3.2
  *
  * Author:      Saint Systems
  * Author URI:  https://www.saintsystems.com

--- a/includes/class-ss-disable-user-login-plugin.php
+++ b/includes/class-ss-disable-user-login-plugin.php
@@ -15,7 +15,7 @@ final class SS_Disable_User_Login_Plugin {
 	 *
 	 * @var string
 	 */
-	private static $version = '1.3.1';
+	private static $version = '1.3.2';
 
 	/**
 	 * Plugin singleton instance
@@ -38,6 +38,15 @@ final class SS_Disable_User_Login_Plugin {
 	 */
 	public static function version() {
 		return self::$version;
+	}
+
+	/**
+	 * Returns the user meta key
+	 *
+	 * @return string
+	 */
+	public static function user_meta_key() {
+		return self::$user_meta_key;
 	}
 
 	/**
@@ -273,25 +282,25 @@ final class SS_Disable_User_Login_Plugin {
 	/**
 	 * Set content of disabled users column
 	 *
-	 * @since 1.0.0
-	 * @param empty $empty
+	 * @since 1.3.2
+	 * @param empty $output
 	 * @param string $column_name
-	 * @param int $user_ID
+	 * @param int $user_id
 	 * @return string
 	 */
-	public function manage_users_column_content( $empty, $column_name, $user_ID ) {
+	public function manage_users_column_content( $output, $column_name, $user_id ) {
 
 		if ( $column_name == 'disable_user_login' ) {
-			if ( get_the_author_meta( self::$user_meta_key, $user_ID ) == 1 ) {
+			if ( get_the_author_meta( self::$user_meta_key, $user_id ) == 1 ) {
 				return __( 'Disabled', 'disable-user-login' );
 			}
 		}
 
-		return $empty; // always return, otherwise we overwrite stuff from other plugins.
+		return $output; // always return, otherwise we overwrite stuff from other plugins.
 	}
 
 	/**
-	 * Specifiy the width of our custom column
+	 * Specify the width of our custom column
 	 *
 	 * @since 1.0.0
  	 */
@@ -419,7 +428,7 @@ final class SS_Disable_User_Login_Plugin {
 			do_action( 'disable_user_login.user_enabled', $user_id );
 		}
  		/**
-		 * Trigger an action when a user's account is enabled
+		 * Trigger an action when an enabled user's account is disabled
 		 *
 		 * @since 1.2.0
 		 * @param int $user_id The ID of the user being disabled

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: users, user, login, account, disable
 Requires at least: 4.7.0
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv3
 
 Provides the ability to disable user accounts and prevent them from logging in.
@@ -47,6 +47,10 @@ Yes, there is a filter in place for that, `disable_user_login_notice`.
 2. Message when a disabled user tries to login.
 
 == Changelog ==
+
+= 1.3.2 =
+* Static method to return user meta key
+* Fix some comments
 
 = 1.3.1 =
 * Update to prevent disabling super admins on bulk disable.


### PR DESCRIPTION
# Summary

This pull request makes a few very small changes, and then increments the version for a patch release.
- new method for returning the meta key
- update version
- change parameter names in `manage_users_column_content` to match [WordPress](https://developer.wordpress.org/reference/hooks/manage_users_custom_column/) docs 
- fix up a couple of comments

This is a proposed change -- happy to modify any of it.

### new method to return meta key

I am using this plugin for [another project](https://github.com/cds-snc/gc-articles) where we want to be able to disable users who don't log in for a set amount of time. This plugin has all the functionality we need to enable/disable accounts, but [we are copying and pasting the meta key string](https://github.com/cds-snc/gc-articles/blob/f579f12645e72b3c5c21b2183c50285fa765174b/wordpress/wp-content/mu-plugins/cds-base/classes/Modules/Users/UserLockout.php#L11), which means it would all break if this plugin changed the meta key string in the future. 

We can live without this method but it seems fairly innocuous, so I figured it would be an easy PR to add it.

### update version

When you download this plugin from [the WordPress directory](https://wordpress.org/plugins/disable-user-login/) (using "Download"), you don't get the `return $empty;` statement in `manage_users_column_content`. I think it's because the version wasn't bumped when that change went in: https://github.com/saintsystems/disable-user-login/pull/3/files

Updated to `1.3.2` because all the changes are very minor.

 ### change parameter names in `manage_users_column_content`
 
I changed the parameter names in `manage_users_column_content` to match what's on the documentation for the [`manage_users_custom_column` hook](https://developer.wordpress.org/reference/hooks/manage_users_custom_column/).

### fix up a couple of comments

I was initially thrown for a loop when reading the comment above the custom "enable user" action hook because it claimed that it was for users who are disabled. 
